### PR TITLE
fix(cicd): Add missing environmental varible.

### DIFF
--- a/.github/workflows/trylinks-cicd-develop.js.yml
+++ b/.github/workflows/trylinks-cicd-develop.js.yml
@@ -24,6 +24,8 @@ jobs:
       HOST: ${{ vars.HOST }}
       NODE_ENV: ${{ vars.NODE_ENV }}
       PROD_ORIGIN: ${{vars.PROD_ORIGIN}}
+      PROD_DOMAIN: ${{vars.PROD_ORIGIN}}
+
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/trylinks-cicd-production.js.yml
+++ b/.github/workflows/trylinks-cicd-production.js.yml
@@ -24,6 +24,8 @@ jobs:
       HOST: ${{ vars.HOST }}
       NODE_ENV: ${{ vars.NODE_ENV }}
       PROD_ORIGIN: ${{vars.PROD_ORIGIN}}
+      PROD_DOMAIN: ${{vars.PROD_ORIGIN}}
+
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This was accidentally removed in the previous commit when optimizing the CICD pipeline.