### PR TITLE
fix(client): fix signup failure bug

### DIFF
--- a/client/src/app/trylinks.service.ts
+++ b/client/src/app/trylinks.service.ts
@@ -47,7 +47,8 @@ export class TrylinksService {
         },
         {
           headers: TrylinksService.headers,
-          withCredentials: true
+          withCredentials: true,
+          observe: 'response'
         }
       )
       .pipe(


### PR DESCRIPTION
This fixes part of issue #14. When a user signed up the client used to always display failure even if it succeeded in the BE and created a user. It turns out that this was an issue in the comparison response.status = 200, as instead of examining the response code, we were examining the response's field status which contained either "success" or "failure", this was because obeserve: response was missing which allows us to examine status codes in the response.