### PR TITLE
feat(cicd): only run CICD on push

### DIFF
--- a/.github/workflows/trylinks-cicd-develop.js.yml
+++ b/.github/workflows/trylinks-cicd-develop.js.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [develop]
-  pull_request:
-    branches: [develop]
-
 
 jobs:
   build:

--- a/.github/workflows/trylinks-cicd-production.js.yml
+++ b/.github/workflows/trylinks-cicd-production.js.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
This repo is about to become public and we must prevent unauthorized deployment of code. This is achived by only deploying on push, as we can review user's pull requests to develop, then, they will only be deployed if approved, and it this goes well, dev will be merge into main and deployed.